### PR TITLE
Disable EXT FS journaling

### DIFF
--- a/nodepool/scripts/convert_node_to_xenserver.sh
+++ b/nodepool/scripts/convert_node_to_xenserver.sh
@@ -93,6 +93,7 @@ FLAG_FILE_INTERNAL=is_internal
 
 
 function main {
+    echo -e "\n\nStarted at $(date)\n"
     case "$(get_state)" in
         "START")
             sed -ie 's/^ - resizefs$//' /etc/cloud/cloud.cfg
@@ -153,6 +154,7 @@ function main {
             create_done_file_on_appliance
             ;;
     esac
+    echo -e "\n\nEnded at $(date)\n"
 }
 
 function set_state {
@@ -550,6 +552,23 @@ function configure_networking {
     xe vif-create vm-uuid=$VM network-uuid=$HOST_INT_NET device=0
     xe vif-create vm-uuid=$VM network-uuid=$ORIGINAL_MGT_NET mac=$MACADDRESS device=1
     xe vif-create vm-uuid=$VM network-uuid=$NEW_MGT_NET device=2
+
+    # Disable FS journaling.
+    if [ "$APP_IMPORTED_NOW" = "true" ]; then
+        vm_vbd=$(xe vbd-list vm-uuid=$VM --minimal)
+        vm_vdi=$(xe vdi-list vbd-uuids=$vm_vbd --minimal)
+        dom_zero_uuid=$(xe vm-list dom-id=0 --minimal)
+        tmp_vbd=$(xe vbd-create device=0 bootable=false mode=RW type=Disk  vdi-uuid=$vm_vdi vm-uuid=$dom_zero_uuid)
+        xe vbd-plug uuid=$tmp_vbd
+        sr_id=$(xe sr-list name-label="Local storage" --minimal)
+        kpartx -p p -avs  /dev/sm/backend/$sr_id/$vm_vdi
+        tune2fs -l  /dev/mapper/${vm_vdi}p1 | grep "Filesystem features"
+        tune2fs -O ^has_journal /dev/mapper/${vm_vdi}p1
+        tune2fs -l  /dev/mapper/${vm_vdi}p1 | grep "Filesystem features"
+        kpartx -dvs  /dev/sm/backend/$sr_id/$vm_vdi
+        xe vbd-unplug uuid=$tmp_vbd timeout=60
+        xe vbd-destroy uuid=$tmp_vbd
+    fi
 
     xe vm-start uuid=$VM
 

--- a/nodepool/scripts/prepare_node.sh
+++ b/nodepool/scripts/prepare_node.sh
@@ -203,9 +203,13 @@ dig git.openstack.org
 sudo mkdir -p /opt/git
 sudo -i python /opt/nodepool-scripts/cache_git_repos.py $GIT_BASE
 
+# <wjh>: Don't know why we added this but it works without this and there is
+#        no evidence showing we should mount ext3 as ext4. So let's comment it
+#        out and we can add back if we met issue (then we can add more reasons).
+#
 # We don't always get ext4 from our clouds, mount ext3 as ext4 on the next
 # boot (eg when this image is used for testing).
-sudo sed -i 's/ext3/ext4/g' /etc/fstab
+#sudo sed -i 's/ext3/ext4/g' /etc/fstab
 
 # Remove additional sources used to install puppet or special version of pypi.
 # We do this because leaving these sources in place causes every test that


### PR DESCRIPTION
With FS journaling enabled, it will consume much IO for journaling.
But CI test nodes are one-time boot/running nodes for CI jobs,
journaling is not needed. So let's disable it.
And this commit contains other two changes:
1. commented out the commands which mounts ext3 fs as ext4;
2. In post-install script, move the scripts which prepare devstack
VM from localrc to /etc/rc3.d/ and make it to be executed as the
last start-up script in run level3. The purpose is to make XS is
accessible if the scripts get stuck.