### PR TITLE
Update hostname in /etc/hosts to avoid sudo warnings

### DIFF
--- a/nodepool/scripts/convert_node_to_xenserver.sh
+++ b/nodepool/scripts/convert_node_to_xenserver.sh
@@ -692,6 +692,9 @@ function configure_hostname {
 
     if [ -n "$HOSTNAME" ]; then
         {
+            # Update hosts to avoid warning when running sudo command:
+            # e.g. sudo: unable to resolve host dsvm-devstack-rax-iad-nodepool-726969
+            echo "sudo sed -i 's/^127.0.1.1.*$/127.0.1.1 '$HOSTNAME'/g' /etc/hosts"
             echo "echo $HOSTNAME | sudo tee /etc/hostname; sudo hostname $HOSTNAME"
         } | bash_on_appliance
     fi


### PR DESCRIPTION
If the hostname is not updated in /etc/hosts, it will produce many
warnings when running sudo commands similar as the following:
sudo: unable to resolve host dsvm-devstack-rax-iad-nodepool-xxxxx