### PR TITLE
Fix issues jenkins jobs and update nodes' labels used for CI jobs

### DIFF
--- a/jenkins/jobs/coverage.yaml
+++ b/jenkins/jobs/coverage.yaml
@@ -1,10 +1,10 @@
 
 - job:
     name: 'check-coverage'
-    node: {node}
+    node: '{node}'
 
     wrappers:
-      - build-timeout:
+      - timeout:
           timeout: 60
       - timestamps
 

--- a/jenkins/jobs/jobs.yaml
+++ b/jenkins/jobs/jobs.yaml
@@ -68,8 +68,6 @@
       - timeout:
           timeout: 230  # Timeout in *minutes*
           fail: true  # A job run that exceeds the timeout will cause a failure
-      - dom0_ip:
-          dom0_ip: 192.168.33.2 # Dom0 ip adress
       - timestamps
 
     builders:
@@ -119,7 +117,8 @@
               exit 137
           fi
 
-      - copy-dom0-logs # In macros.yaml from os-ext-testing
+      - copy-dom0-logs: # In macros.yaml from os-ext-testing
+          dom0_ip: '192.168.33.2' # Dom0 ip adress
       - link-logs  # In macros.yaml from os-ext-testing
 
     publishers:
@@ -177,7 +176,7 @@
 
 - job:
     name: 'check-zuul-layout-update'
-    node: {node}
+    node: '{node}'
 
     wrappers:
       - timeout:

--- a/jenkins/jobs/macros-common.yaml
+++ b/jenkins/jobs/macros-common.yaml
@@ -62,12 +62,13 @@
 
 - builder:
     name: copy-dom0-logs
+    dom0_ip: '{dom0_ip}'
     builders:
       - shell: |
           #!/bin/sh
           # make dir on jekins server to save Dom0 logs
           sudo -u domzero mkdir -p ~domzero/logs
-          sudo -u domzero scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{dom0_ip}:/var/log/\{messages*,user.log*,SMlog*,xensource.log*\} /home/domzero/logs/
+          sudo -u domzero scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{dom0_ip}:/var/log/\{{messages*,user.log*,SMlog*,xensource.log*\}} /home/domzero/logs/
           sudo -u domzero chmod -R 755 ~domzero/logs
 
 - publisher:

--- a/jenkins/jobs/projects.yaml
+++ b/jenkins/jobs/projects.yaml
@@ -6,16 +6,14 @@
 
     jobs:
         - dsvm-tempest-nova-network:
-            node: 'rax-iad-devstack || citrix-lon-devstack || citrix-mia-devstack'
+            node: 'dsvm-devstack'
         - dsvm-tempest-neutron-network:
-            node: 'rax-iad-devstack || citrix-lon-devstack || citrix-mia-devstack'
-        - check-fuel-plugin-xenserver-7.0:
+            node: 'dsvm-devstack'
+        - check-fuel-plugin-xenserver-{xenserver_version}:
             node: 'fuel-xenserver'
-            xenserver_version: 7.0
-        - check-fuel-plugin-xenserver-6.5:
+            xenserver_version: '7.0'
+        - check-fuel-plugin-xenserver-{xenserver_version}:
             node: 'fuel-xenserver-65'
-            xenserver_version: 6.5
+            xenserver_version: '6.5'
         - check-coverage:
-            node: 'citrix-lon-coverage || citrix-mia-devstack'
-        - check-zuul-layout-update:
-            node: 'coverage'
+            node: 'ubuntu-xenial-coverage'


### PR DESCRIPTION
There are several bugs in current jenkins jobs config:
1. dom0_ip was wrongly used in wrappers section;
2. timeout for coverage was wrong
3. nodes' lables didn't match the ones actually used.

This commit is to correct all and ensure the configures are up-to-date.