### PR TITLE
Citrix CI: fix logs upload failure

### DIFF
--- a/jenkins/jobs/macros-common.yaml
+++ b/jenkins/jobs/macros-common.yaml
@@ -115,7 +115,10 @@
           ls -l logs logs/run_tests.log
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
+          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
+          mkdir -p ~/.config/openstack/
+          cp swift-uploader/clouds.yaml ~/.config/openstack/
           sudo chmod -R 0777 ~/.ccache/
           #sudo chmod -R 0777 /home/jenkins/.ccache/
           pip install -r swift-uploader/requirements.txt
@@ -133,7 +136,10 @@
           ls -l test.log logs
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
+          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
+          mkdir -p ~/.config/openstack/
+          cp swift-uploader/clouds.yaml ~/.config/openstack/
           sudo chmod -R 0777 ~/.ccache/
           #sudo chmod -R 0777 /home/jenkins/.ccache/
           pip install -r swift-uploader/requirements.txt
@@ -148,7 +154,10 @@
           ls -l {upload_source}
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
+          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
+          mkdir -p ~/.config/openstack/
+          cp swift-uploader/clouds.yaml ~/.config/openstack/
           sudo chmod 0777 /home/jenkins/.ccache/
           pip install -r swift-uploader/requirements.txt
           swift-uploader/swiftuploader/upload.py -r DFW --password $PASSWD -c CILogs {upload_source} $LOG_PATH

--- a/jenkins/jobs/vgpu.yaml
+++ b/jenkins/jobs/vgpu.yaml
@@ -49,7 +49,10 @@
           LOG_PATH=${{LOG_PATH:-$BUILD_TAG}}
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
+          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
+          mkdir -p ~/.config/openstack/
+          cp swift-uploader/clouds.yaml ~/.config/openstack/
           pip install -r swift-uploader/requirements.txt
           swift-uploader/swiftuploader/upload.py -r DFW --password $PASSWD -c CILogs test.log logs $LOG_PATH
           echo "Detailed logs: http://dd6b71949550285df7dc-dda4e480e005aaa13ec303551d2d8155.r49.cf1.rackcdn.com/$LOG_PATH/"


### PR DESCRIPTION
Because of openstack sdk upgrade, connection creates would be failed
because of API changes. Used new API to fix this error.
Need install pkg os_client_config and set cloud.yaml.