### PR TITLE
Remove pip installation for os_client_config

### DIFF
--- a/jenkins/jobs/macros-common.yaml
+++ b/jenkins/jobs/macros-common.yaml
@@ -115,7 +115,6 @@
           ls -l logs logs/run_tests.log
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
-          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
           mkdir -p ~/.config/openstack/
           cp swift-uploader/clouds.yaml ~/.config/openstack/
@@ -136,7 +135,6 @@
           ls -l test.log logs
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
-          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
           mkdir -p ~/.config/openstack/
           cp swift-uploader/clouds.yaml ~/.config/openstack/
@@ -154,7 +152,6 @@
           ls -l {upload_source}
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
-          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
           mkdir -p ~/.config/openstack/
           cp swift-uploader/clouds.yaml ~/.config/openstack/

--- a/jenkins/jobs/vgpu.yaml
+++ b/jenkins/jobs/vgpu.yaml
@@ -49,7 +49,6 @@
           LOG_PATH=${{LOG_PATH:-$BUILD_TAG}}
           virtualenv swift-uploader-env
           . swift-uploader-env/bin/activate
-          pip install os_client_config
           git clone https://github.com/citrix-openstack/swift-uploader.git swift-uploader
           mkdir -p ~/.config/openstack/
           cp swift-uploader/clouds.yaml ~/.config/openstack/


### PR DESCRIPTION
As os-client-config is included in swift-upload's requirements,
the package of os-client-config will be installed by:
``pip install -r swift-uploader/requirements.txt``.
That behavior is more reasonable and easier for control. So
remove the commands for manual installation.

https://github.com/citrix-openstack/swift-uploader/blob/master/requirements.txt#L2