### PR TITLE
Install a new package libpcre3-dev

### DIFF
--- a/nodepool/scripts/install_devstack_dependencies.sh
+++ b/nodepool/scripts/install_devstack_dependencies.sh
@@ -35,7 +35,7 @@ elif [ -f /usr/bin/apt-get ]; then
             --option "Dpkg::Options::=--force-confold" \
             --assume-yes install build-essential python-dev libssl-dev libffi-dev \
             python-software-properties linux-headers-virtual linux-headers-`uname -r` \
-            default-jre iptables
+            default-jre iptables libpcre3-dev
     fi
 else
     echo "Unsupported distro."


### PR DESCRIPTION
We need add this package of libpcre3-dev as it's depended by
python-pcre. Otherwise it will fail to install python-pcre with
erros as:

x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c src/pcremodule.c -o build/temp.linux-x86_64-2.7/src/pcremodule.o -fno-strict-aliasing
src/pcremodule.c:32:18: fatal error: pcre.h: No such file or directory
compilation terminated.
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1