### PR TITLE
Set zuul version as 2.5.1

### DIFF
--- a/nodepool/scripts/prepare_node.sh
+++ b/nodepool/scripts/prepare_node.sh
@@ -22,6 +22,10 @@ SUDO=${SUDO:-true}
 THIN=${THIN:-true}
 ALL_MYSQL_PRIVS=${ALL_MYSQL_PRIVS:-false}
 GIT_BASE=${GIT_BASE:-git://git.openstack.org}
+# By default use 2.5.1 to avoid compatiblity issue:
+# e.g. the version of 2.6.1.dev* introduced dependent package: aiohttp which
+#      requires python >=3.4.2. But at the moment we run python2.7.
+ZUUL_VERSION=${ZUUL_VERSION:-2.5.1}
 
 # delete stack user if exists, in case the base XVA has this user already.
 if id stack ; then
@@ -263,7 +267,7 @@ sudo rm -f /etc/cron.{monthly,weekly,daily,hourly,d}/*
 # Install Zuul into a virtualenv
 # This is in /usr instead of /usr/local due to this bug on precise:
 # https://bugs.launchpad.net/ubuntu/+source/python2.7/+bug/839588
-git clone /opt/git/openstack-infra/zuul /tmp/zuul
+git clone /opt/git/openstack-infra/zuul -b $ZUUL_VERSION /tmp/zuul
 sudo virtualenv /usr/zuul-env
 sudo -H /usr/zuul-env/bin/pip install /tmp/zuul
 sudo rm -fr /tmp/zuul


### PR DESCRIPTION
As the latest 2.6.1.dev version zuul added more dependent packages
which have broken our image building, let's set the zuul version
as 2.5.1 before we migrate the CI env to zuul3.

Error log:
018-01-29 12:26:35,241 INFO nodepool.image.build.citrix-mia-nodepool.devstack: 2018-01-29 04:26:22.457 |   Downloading aiohttp-2.3.1.tar.gz (1.1MB)
2018-01-29 12:26:35,246 INFO nodepool.image.build.citrix-mia-nodepool.devstack: 2018-01-29 04:26:22.462 | aiohttp requires Python '>=3.4.2' but the running Python is 2.7.12
2018-01-29 12:26:35,330 DEBUG nodepool.image.build.citrix-mia-nodepool.devstack: *** FAILED to run setup script (1)